### PR TITLE
New python fitting script from Brady (for egamma-tnp)

### DIFF
--- a/python/basic_tools.py
+++ b/python/basic_tools.py
@@ -1,0 +1,9 @@
+# basic_tools.py
+
+import os
+
+# creates directory if it does not exist
+def makeDir(dir_name):
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+

--- a/python/basic_tools.py
+++ b/python/basic_tools.py
@@ -1,9 +1,17 @@
 # basic_tools.py
 
 import os
+import matplotlib.pyplot as plt
 
-# creates directory if it does not exist
+# Creates directory if it does not exist
 def makeDir(dir_name):
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
+
+# Save plot to png and pdf
+def savePlot(plot_dir, plot_name):
+    output_png = "{0}/{1}.png".format(plot_dir, plot_name)
+    output_pdf = "{0}/{1}.pdf".format(plot_dir, plot_name)
+    plt.savefig(output_png, bbox_inches='tight')
+    plt.savefig(output_pdf, bbox_inches='tight')
 

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -90,12 +90,10 @@ def fit_hist(hist, hist_name, plot_dir):
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
     
-    # TODO: Replace with savePlot(plot_dir, plot_name)
-
     # Save plot
-    output_file = hist_name
-    plt.savefig(f"{plot_dir}/{output_file}.png")
-    plt.savefig(f"{plot_dir}/{output_file}.pdf")
+    plot_name = f"fit_{hist_name}"
+    basic_tools.savePlot(plot_dir, plot_name)
+    
     plt.close()
     
     print("Finished fit!")

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -1,0 +1,98 @@
+import uproot
+import numpy as np
+from scipy.optimize import curve_fit
+import matplotlib.pyplot as plt
+from scipy.stats import norm
+import mplhep as hep
+
+# Specify the histogram name and open the ROOT file 
+histogram_name = "bin11_pt_32p00To34p00_Pass"
+root_file = uproot.open("DY_2023C_pt_barrel.root")
+
+def load_histogram(root_file, hist_name):
+    keys = {key.split(";")[0]: key for key in root_file.keys()}
+    if hist_name in keys:
+        obj = root_file[keys[hist_name]]
+        if isinstance(obj, uproot.behaviors.TH1.Histogram):
+            values, edges = obj.to_numpy()
+            return {"values": values, "edges": edges}
+    return None
+
+# Load the histogram using the opened file and specified name
+hist = load_histogram(root_file, histogram_name)
+
+def gaussian_exponential(x, A, mu, sigma, B, tau):
+    return A * norm.pdf(x, mu, sigma) + B * np.exp(-x / tau)
+
+def compute_signal_background_events(x, popt):
+    """
+    Compute integrated signal and background events using the fitted parameters.
+    """
+    # Compute the Gaussian (signal) and  exponential (background) 
+    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
+    expo = popt[3] * np.exp(-x / popt[4])
+    # Integrate each component
+    signal_events = np.trapezoid(gauss, x)
+    background_events = np.trapezoid(expo, x)
+    return signal_events, background_events
+
+def plotHist(hist, plot_dir, output_file):
+    plt.figure(figsize=(12, 8))
+    hep.style.use("CMS")
+
+    centers = (hist["edges"][:-1] + hist["edges"][1:]) / 2
+    values = hist["values"]
+    errors = np.sqrt(values) 
+
+    # Plot data points with error bars
+    plt.errorbar(centers, values, yerr=errors, fmt='o',
+                 label=f"{output_file} Data Points", capsize=3)
+
+    # Fit a Gaussian + Exponential background model
+    p0 = [max(values), 90, 10, min(values), 20]  # Initial guess: [A, mu, sigma, B, tau]
+    popt, pcov = curve_fit(gaussian_exponential, centers, values, p0=p0)
+    perr = np.sqrt(np.diag(pcov))  # uncertainties
+
+    x = np.linspace(min(centers), max(centers), 100)
+    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
+    expo = popt[3] * np.exp(-x / popt[4])
+    combined = gaussian_exponential(x, *popt)
+
+    # Compute the integrated signal and background events
+    signal_events, background_events = compute_signal_background_events(x, popt)
+    print(f"Estimated number of signal events: {signal_events}")
+    print(f"Estimated number of background events: {background_events}")
+
+    # Plot the fitted components and combined fit
+    plt.plot(x, gauss, label="Gaussian (Signal)")
+    plt.plot(x, expo, label="Exponential (Background)")
+    plt.plot(x, combined, label="Combined Fit")
+    
+    #Display the fit parameters and event counts
+    legend_text = (
+        f"Gaussian (Signal): A={popt[0]:.2f}, μ={popt[1]:.2f}, σ={popt[2]:.2f}\n"
+        f"Exponential (Background): B={popt[3]:.2f}, τ={popt[4]:.2f}\n"
+        f"Signal Events: {signal_events:.2f}\n"
+        f"Background Events: {background_events:.2f}"
+    )
+    
+    # legend for the curves
+    leg = plt.legend(loc='upper right', fontsize=8, frameon=True)
+    leg.get_frame().set_linewidth(1)
+    leg.get_frame().set_edgecolor('black')
+    leg.get_frame().set_alpha(1)
+    
+    # Add a text box in the upper left with the detailed information
+    plt.text(0.05, 0.95, legend_text, transform=plt.gca().transAxes, fontsize=8,
+             verticalalignment='top', bbox=dict(facecolor='white', alpha=0.8))
+    
+    # Set the plot title and label axes 
+    plt.xlabel("pT")
+    plt.title(histogram_name)
+    plt.savefig(f"{plot_dir}/{output_file}.png")
+    plt.close()
+
+# Call the function to generate and save the plot, also assigning the name to match the histogram name
+
+plotHist(hist, "plots", histogram_name)
+

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -16,6 +16,8 @@ def load_histogram(root_file, hist_name):
     return None
 
 def fit_hist(hist, hist_name, plot_dir):
+    print(f"Fitting histogram '{hist_name}' ...")
+
     basic_tools.makeDir(plot_dir)
 
     plt.figure(figsize=(12, 8))
@@ -26,8 +28,14 @@ def fit_hist(hist, hist_name, plot_dir):
     errors = np.sqrt(values) 
 
     # Plot data points with error bars
-    plt.errorbar(centers, values, yerr=errors, fmt='o',
-                 label=f"{hist_name} Data Points", capsize=3)
+    plt.errorbar(
+        centers,
+        values,
+        yerr=errors,
+        fmt='o',
+        label=f"Data Points ({hist_name})",
+        capsize=3
+    )
 
     # Fit a Gaussian + Exponential background model
     p0 = [max(values), 90, 10, min(values), 20]  # Initial guess: [A, mu, sigma, B, tau]
@@ -35,19 +43,19 @@ def fit_hist(hist, hist_name, plot_dir):
     perr = np.sqrt(np.diag(pcov))  # uncertainties
 
     x = np.linspace(min(centers), max(centers), 100)
-    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
-    expo = popt[3] * np.exp(-x / popt[4])
+    gauss   = popt[0] * norm.pdf(x, popt[1], popt[2])
+    expo    = popt[3] * np.exp(-x / popt[4])
     combined = gaussian_exponential(x, *popt)
 
     # Compute the integrated signal and background events
     signal_events, background_events = compute_signal_background_events(x, popt)
-    print(f"Estimated number of signal events: {signal_events}")
-    print(f"Estimated number of background events: {background_events}")
+    print(f" - Estimated number of signal events: {signal_events:.2f}")
+    print(f" - Estimated number of background events: {background_events:.2f}")
 
     # Plot the fitted components and combined fit
-    plt.plot(x, gauss, label="Gaussian (Signal)")
-    plt.plot(x, expo, label="Exponential (Background)")
-    plt.plot(x, combined, label="Combined Fit")
+    plt.plot(x, gauss,      label="Gaussian (Signal)")
+    plt.plot(x, expo,       label="Exponential (Background)")
+    plt.plot(x, combined,   label="Combined Fit")
     
     # Display the fit parameters and event counts
     legend_text = (
@@ -64,13 +72,23 @@ def fit_hist(hist, hist_name, plot_dir):
     leg.get_frame().set_alpha(1)
     
     # Add a text box in the upper left with the detailed information
-    plt.text(0.05, 0.95, legend_text, transform=plt.gca().transAxes, fontsize=8,
-             verticalalignment='top', bbox=dict(facecolor='white', alpha=0.8))
+    plt.text(
+        0.05,
+        0.95,
+        legend_text,
+        transform=plt.gca().transAxes,
+        fontsize=8,
+        verticalalignment='top',
+        bbox=dict(facecolor='white', alpha=0.8)
+    )
     
     # Set the plot title and label axes 
-    plt.title(hist_name)
-    plt.xlabel(r"$p_{T}$ [GeV]")
-    plt.ylabel("Number of events")
+    title   = f"Fit to {hist_name}"
+    xlabel  = r"$m_{ee}$ [GeV]"
+    ylabel  = "Number of events"
+    plt.title(title)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
     
     # TODO: Replace with savePlot(plot_dir, plot_name)
 
@@ -79,6 +97,8 @@ def fit_hist(hist, hist_name, plot_dir):
     plt.savefig(f"{plot_dir}/{output_file}.png")
     plt.savefig(f"{plot_dir}/{output_file}.pdf")
     plt.close()
+    
+    print("Finished fit!")
 
 def gaussian_exponential(x, A, mu, sigma, B, tau):
     return A * norm.pdf(x, mu, sigma) + B * np.exp(-x / tau)
@@ -88,17 +108,17 @@ def compute_signal_background_events(x, popt):
     Compute integrated signal and background events using the fitted parameters.
     """
     # Compute the Gaussian (signal) and  exponential (background) 
-    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
-    expo = popt[3] * np.exp(-x / popt[4])
+    gauss   = popt[0] * norm.pdf(x, popt[1], popt[2])
+    expo    = popt[3] * np.exp(-x / popt[4])
     # Integrate each component
-    signal_events = np.trapezoid(gauss, x)
-    background_events = np.trapezoid(expo, x)
+    signal_events       = np.trapezoid(gauss, x)
+    background_events   = np.trapezoid(expo, x)
     return signal_events, background_events
 
 def main():
     # Specify the histogram name and directory to save plots
     hist_name   = "bin11_pt_32p00To34p00_Pass"
-    plot_dir    = "egamma_tnp_fits"
+    plot_dir    = "egamma_data_2023C_fits"
     
     # Open ROOT file
     #root_file = uproot.open("DY_2023C_pt_barrel.root")

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -6,11 +6,6 @@ from scipy.stats import norm
 import mplhep as hep
 import basic_tools
 
-# Specify the histogram name and open the ROOT file 
-histogram_name = "bin11_pt_32p00To34p00_Pass"
-#root_file = uproot.open("DY_2023C_pt_barrel.root")
-root_file = uproot.open("egamma_tnp_output/egamma_output_2025_02_03_run_1/HLT_Ele30_WPTight_Gsf_histos_pt_barrel.root")
-
 def load_histogram(root_file, hist_name):
     keys = {key.split(";")[0]: key for key in root_file.keys()}
     if hist_name in keys:
@@ -20,25 +15,7 @@ def load_histogram(root_file, hist_name):
             return {"values": values, "edges": edges}
     return None
 
-# Load the histogram using the opened file and specified name
-hist = load_histogram(root_file, histogram_name)
-
-def gaussian_exponential(x, A, mu, sigma, B, tau):
-    return A * norm.pdf(x, mu, sigma) + B * np.exp(-x / tau)
-
-def compute_signal_background_events(x, popt):
-    """
-    Compute integrated signal and background events using the fitted parameters.
-    """
-    # Compute the Gaussian (signal) and  exponential (background) 
-    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
-    expo = popt[3] * np.exp(-x / popt[4])
-    # Integrate each component
-    signal_events = np.trapezoid(gauss, x)
-    background_events = np.trapezoid(expo, x)
-    return signal_events, background_events
-
-def plotHist(hist, plot_dir, output_file):
+def plotHist(hist, plot_dir, hist_name):
     basic_tools.makeDir(plot_dir)
 
     plt.figure(figsize=(12, 8))
@@ -50,7 +27,7 @@ def plotHist(hist, plot_dir, output_file):
 
     # Plot data points with error bars
     plt.errorbar(centers, values, yerr=errors, fmt='o',
-                 label=f"{output_file} Data Points", capsize=3)
+                 label=f"{hist_name} Data Points", capsize=3)
 
     # Fit a Gaussian + Exponential background model
     p0 = [max(values), 90, 10, min(values), 20]  # Initial guess: [A, mu, sigma, B, tau]
@@ -72,7 +49,7 @@ def plotHist(hist, plot_dir, output_file):
     plt.plot(x, expo, label="Exponential (Background)")
     plt.plot(x, combined, label="Combined Fit")
     
-    #Display the fit parameters and event counts
+    # Display the fit parameters and event counts
     legend_text = (
         f"Gaussian (Signal): A={popt[0]:.2f}, μ={popt[1]:.2f}, σ={popt[2]:.2f}\n"
         f"Exponential (Background): B={popt[3]:.2f}, τ={popt[4]:.2f}\n"
@@ -80,7 +57,7 @@ def plotHist(hist, plot_dir, output_file):
         f"Background Events: {background_events:.2f}"
     )
     
-    # legend for the curves
+    # Create legend
     leg = plt.legend(loc='upper right', fontsize=8, frameon=True)
     leg.get_frame().set_linewidth(1)
     leg.get_frame().set_edgecolor('black')
@@ -91,11 +68,37 @@ def plotHist(hist, plot_dir, output_file):
              verticalalignment='top', bbox=dict(facecolor='white', alpha=0.8))
     
     # Set the plot title and label axes 
+    output_file = hist_name
     plt.xlabel("pT")
-    plt.title(histogram_name)
+    plt.title(hist_name)
     plt.savefig(f"{plot_dir}/{output_file}.png")
     plt.close()
 
-# Call the function to generate and save the plot, also assigning the name to match the histogram name
-plotHist(hist, "egamma_tnp_fits", histogram_name)
+def gaussian_exponential(x, A, mu, sigma, B, tau):
+    return A * norm.pdf(x, mu, sigma) + B * np.exp(-x / tau)
+
+def compute_signal_background_events(x, popt):
+    """
+    Compute integrated signal and background events using the fitted parameters.
+    """
+    # Compute the Gaussian (signal) and  exponential (background) 
+    gauss = popt[0] * norm.pdf(x, popt[1], popt[2])
+    expo = popt[3] * np.exp(-x / popt[4])
+    # Integrate each component
+    signal_events = np.trapezoid(gauss, x)
+    background_events = np.trapezoid(expo, x)
+    return signal_events, background_events
+
+def main():
+    # Specify the histogram name and open the ROOT file 
+    hist_name = "bin11_pt_32p00To34p00_Pass"
+    #root_file = uproot.open("DY_2023C_pt_barrel.root")
+    root_file = uproot.open("egamma_tnp_output/egamma_output_2025_02_03_run_1/HLT_Ele30_WPTight_Gsf_histos_pt_barrel.root")
+    # Load the histogram using the opened file and specified name
+    hist = load_histogram(root_file, hist_name)
+    # Call the function to generate and save the plot, also assigning the name to match the histogram name
+    plotHist(hist, "egamma_tnp_fits", hist_name)
+
+if __name__ == "__main__":
+    main()
 

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -1,8 +1,8 @@
 import uproot
 import numpy as np
 from scipy.optimize import curve_fit
-import matplotlib.pyplot as plt
 from scipy.stats import norm
+import matplotlib.pyplot as plt
 import mplhep as hep
 import basic_tools
 
@@ -15,7 +15,7 @@ def load_histogram(root_file, hist_name):
             return {"values": values, "edges": edges}
     return None
 
-def plotHist(hist, plot_dir, hist_name):
+def fit_hist(hist, hist_name, plot_dir):
     basic_tools.makeDir(plot_dir)
 
     plt.figure(figsize=(12, 8))
@@ -68,10 +68,16 @@ def plotHist(hist, plot_dir, hist_name):
              verticalalignment='top', bbox=dict(facecolor='white', alpha=0.8))
     
     # Set the plot title and label axes 
-    output_file = hist_name
-    plt.xlabel("pT")
     plt.title(hist_name)
+    plt.xlabel(r"$p_{T}$ [GeV]")
+    plt.ylabel("Number of events")
+    
+    # TODO: Replace with savePlot(plot_dir, plot_name)
+
+    # Save plot
+    output_file = hist_name
     plt.savefig(f"{plot_dir}/{output_file}.png")
+    plt.savefig(f"{plot_dir}/{output_file}.pdf")
     plt.close()
 
 def gaussian_exponential(x, A, mu, sigma, B, tau):
@@ -90,14 +96,19 @@ def compute_signal_background_events(x, popt):
     return signal_events, background_events
 
 def main():
-    # Specify the histogram name and open the ROOT file 
-    hist_name = "bin11_pt_32p00To34p00_Pass"
+    # Specify the histogram name and directory to save plots
+    hist_name   = "bin11_pt_32p00To34p00_Pass"
+    plot_dir    = "egamma_tnp_fits"
+    
+    # Open ROOT file
     #root_file = uproot.open("DY_2023C_pt_barrel.root")
     root_file = uproot.open("egamma_tnp_output/egamma_output_2025_02_03_run_1/HLT_Ele30_WPTight_Gsf_histos_pt_barrel.root")
+    
     # Load the histogram using the opened file and specified name
     hist = load_histogram(root_file, hist_name)
+    
     # Call the function to generate and save the plot, also assigning the name to match the histogram name
-    plotHist(hist, "egamma_tnp_fits", hist_name)
+    fit_hist(hist, hist_name, plot_dir)
 
 if __name__ == "__main__":
     main()

--- a/python/fitHist.py
+++ b/python/fitHist.py
@@ -4,10 +4,12 @@ from scipy.optimize import curve_fit
 import matplotlib.pyplot as plt
 from scipy.stats import norm
 import mplhep as hep
+import basic_tools
 
 # Specify the histogram name and open the ROOT file 
 histogram_name = "bin11_pt_32p00To34p00_Pass"
-root_file = uproot.open("DY_2023C_pt_barrel.root")
+#root_file = uproot.open("DY_2023C_pt_barrel.root")
+root_file = uproot.open("egamma_tnp_output/egamma_output_2025_02_03_run_1/HLT_Ele30_WPTight_Gsf_histos_pt_barrel.root")
 
 def load_histogram(root_file, hist_name):
     keys = {key.split(";")[0]: key for key in root_file.keys()}
@@ -37,6 +39,8 @@ def compute_signal_background_events(x, popt):
     return signal_events, background_events
 
 def plotHist(hist, plot_dir, output_file):
+    basic_tools.makeDir(plot_dir)
+
     plt.figure(figsize=(12, 8))
     hep.style.use("CMS")
 
@@ -93,6 +97,5 @@ def plotHist(hist, plot_dir, output_file):
     plt.close()
 
 # Call the function to generate and save the plot, also assigning the name to match the histogram name
-
-plotHist(hist, "plots", histogram_name)
+plotHist(hist, "egamma_tnp_fits", histogram_name)
 

--- a/python/tools.py
+++ b/python/tools.py
@@ -1,7 +1,6 @@
 # tools.py
 
 import os
-import ROOT
 import colors
 
 # creates directory if it does not exist


### PR DESCRIPTION
New python fitting script: `fitHist.py`

Brady created a new python fitting script to run over egamma-tnp output files.
- Input: ROOT file containing dielectron mass pass/fail histograms (output from egamma-tnp framework)
- Output: plot of signal + background fit to histogram

Caleb did the following modifications to the script `fitHist.py`:
- Create main function
- Change title and axis labels
- Format code and print statements
- Create and use helper functions in `basic_tools.py`